### PR TITLE
修复由于Vue3更新导致的CDN错误调用

### DIFF
--- a/html/main.html
+++ b/html/main.html
@@ -1,7 +1,7 @@
 <head>
     <link rel='stylesheet' href='https://synthetic.librian.net/synthetic.css'/>
     <link rel='stylesheet' href='./global.css'/>
-    <script src='https://cdn.jsdelivr.net/npm/vue'></script>
+    <script src='https://cdn.jsdelivr.net/npm/vue@2'></script>
     <script src='./1.js'></script>
     <title>
         幼女Code！


### PR DESCRIPTION
https://cdn.jsdelivr.net/npm/vue 现在会默认加载Vue3
此项目似乎使用Vue2，加载Vue3会导致报错